### PR TITLE
fix: restore removed delete package-lock command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      # - name: Delete package-lock.json
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: rm -f package-lock.json
+      - name: Delete package-lock.json
+        if: matrix.os == 'ubuntu-latest'
+        run: rm -f package-lock.json
 
       - name: Install NPM packages
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      # - name: Delete package-lock.json
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: rm -f package-lock.json
+      - name: Delete package-lock.json
+        if: matrix.os == 'ubuntu-latest'
+        run: rm -f package-lock.json
 
       - name: Install NPM packages
         run: npm install


### PR DESCRIPTION
Restoring delete package-lock.json due to error:

- Checking your system
✔ Checking your system
- Resolving Forge Config
✔ Resolving Forge Config

An unhandled rejection has occurred inside Forge:
Error: Cannot make for linux and target deb: the maker declared that it cannot run on linux

Electron Forge was terminated. Location:
{}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! job-application-tracker-v2@0.1.4 publish: `electron-forge publish`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the job-application-tracker-v2@0.1.4 publish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/[20](https://github.com/TimothyJNewman/job-application-tracker-v2/actions/runs/3166060900/jobs/5155525719#step:5:21)[22](https://github.com/TimothyJNewman/job-application-tracker-v2/actions/runs/3166060900/jobs/5155525719#step:5:23)-10-01T20_34_[24](https://github.com/TimothyJNewman/job-application-tracker-v2/actions/runs/3166060900/jobs/5155525719#step:5:25)_938Z-debug.log
Error: Process completed with exit code 1.